### PR TITLE
Add website change monitoring section to archiving-caching

### DIFF
--- a/docs/archiving-caching.md
+++ b/docs/archiving-caching.md
@@ -20,3 +20,9 @@
 - [yt-dlp](https://github.com/yt-dlp/yt-dlp) — Download and archive YouTube videos  
 - [archivebox](https://github.com/ArchiveBox/ArchiveBox) — Self-hosted webpage archiving solution  
 - [SingleFile](https://github.com/gildas-lormeau/SingleFile) — Browser extension to save complete pages as a single HTML
+
+### Website Change Monitoring
+- [Google Alerts](https://www.google.com/alerts) — Free keyword-based email alerts for web mentions and changes  
+- [VisualPing](https://visualping.io/) — Monitor pages for visual changes and receive alerts (freemium)  
+- [Snaplert](https://snaplert.com/) — Website change monitoring with AI-powered visual diffs, element-level zone picker, and before/after screenshot alerts (free beta)  
+- [Changedetection.io](https://changedetection.io/) — Self-hosted webpage change detection with JSON/XPath support  


### PR DESCRIPTION
Adds a new '### Website Change Monitoring' subsection to the Website Archiving & Caching page.

Website change monitoring is a natural complement to archiving — researchers often need to detect when a target page changes, not just retrieve historical snapshots.

Added tools:
- Google Alerts (free, keyword-based)
- VisualPing (freemium, visual change detection)
- [Snaplert](https://snaplert.com/) (free beta, AI-powered visual diffs with element-level zone picker)
- Changedetection.io (self-hosted, JSON/XPath support)